### PR TITLE
downloadDocument: use arraybuffer responseType

### DIFF
--- a/src/api/user/workgroup.js
+++ b/src/api/user/workgroup.js
@@ -27,7 +27,7 @@ module.exports = function(client, parentPath) {
     return client.api({
       url: `${BASE_PATH}/${workGroupUuid}/nodes/${documentUuid}/download`,
       method: 'GET',
-      responseType: 'blob'
+      responseType: 'arraybuffer'
     });
   }
 };


### PR DESCRIPTION
Hi,

This fixes issues when downloading binary files (ex a pdf), some bytes were re-encoded

Cheers,
Pierre